### PR TITLE
#14 make buffer mappings configurable

### DIFF
--- a/lua/yode-nvim/changeSyncing.lua
+++ b/lua/yode-nvim/changeSyncing.lua
@@ -70,10 +70,7 @@ local onSeditorBufferLines = function(_, bufId, _, firstline, lastline, newLastl
     local seditorWindow = seditors.selectors.getSeditorById(bufId)
     local operationType = h.getOperationOfBufLinesEvent(firstline, lastline, linedata)
     local lineData = seditorWindow.indentCount
-            and h.map(
-                R.concat(h.createWhiteSpace(seditorWindow.indentCount)),
-                linedata
-            )
+            and h.map(R.concat(h.createWhiteSpace(seditorWindow.indentCount)), linedata)
         or linedata
 
     log.debug(bufId, operationType, {
@@ -278,11 +275,8 @@ local onFileBufferLines = function(_, bufId, tick, firstline, lastline, newLastl
     local linedata = vim.api.nvim_buf_get_lines(bufId, firstline, newLastline, true)
     local lineLength = lastline - firstline
     local dataLength = #linedata
-    local operationType, editLineCount = h.getOperationOfBufLinesEvent(
-        firstline,
-        lastline,
-        linedata
-    )
+    local operationType, editLineCount =
+        h.getOperationOfBufLinesEvent(firstline, lastline, linedata)
     log.debug(
         bufId,
         'lines:',

--- a/lua/yode-nvim/createSeditor.lua
+++ b/lua/yode-nvim/createSeditor.lua
@@ -1,5 +1,6 @@
 local h = require('yode-nvim.helper')
 local logging = require('yode-nvim.logging')
+local handlers = require('yode-nvim.handlers')
 local storeBundle = require('yode-nvim.redux.index')
 local seditors = storeBundle.seditors
 local R = require('yode-nvim.deps.lamda.dist.lamda')
@@ -46,16 +47,7 @@ local createSeditor = function(opts)
     local name = getFileBufferName(fileBufferId, seditorBufferId)
     vim.api.nvim_buf_call(seditorBufferId, function()
         vim.cmd('file ' .. name)
-        vim.cmd([[
-            nmap <buffer> <leader>bll :YodeGoToAlternateBuffer<cr>
-            imap <buffer> <leader>bll <esc>:YodeGoToAlternateBuffer<cr>
-            nmap <buffer> <leader>blt :YodeGoToAlternateBuffer t<cr>
-            imap <buffer> <leader>blt <esc>:YodeGoToAlternateBuffer t<cr>
-            nmap <buffer> <leader>blz :YodeGoToAlternateBuffer z<cr>
-            imap <buffer> <leader>blz <esc>:YodeGoToAlternateBuffer z<cr>
-            nmap <buffer> <leader>blb :YodeGoToAlternateBuffer b<cr>
-            imap <buffer> <leader>blb <esc>:YodeGoToAlternateBuffer b<cr>
-        ]])
+        handlers.fns.onSeditorBufCal()
     end)
     return seditorBufferId
 end

--- a/lua/yode-nvim/defaultConfig.lua
+++ b/lua/yode-nvim/defaultConfig.lua
@@ -1,5 +1,19 @@
 local M = {
     log = {},
+    handlers = {
+        onSeditorBufCal = function()
+            vim.cmd([[
+                nmap <buffer> <leader>bll :YodeGoToAlternateBuffer<cr>
+                imap <buffer> <leader>bll <esc>:YodeGoToAlternateBuffer<cr>
+                nmap <buffer> <leader>blt :YodeGoToAlternateBuffer t<cr>
+                imap <buffer> <leader>blt <esc>:YodeGoToAlternateBuffer t<cr>
+                nmap <buffer> <leader>blz :YodeGoToAlternateBuffer z<cr>
+                imap <buffer> <leader>blz <esc>:YodeGoToAlternateBuffer z<cr>
+                nmap <buffer> <leader>blb :YodeGoToAlternateBuffer b<cr>
+                imap <buffer> <leader>blb <esc>:YodeGoToAlternateBuffer b<cr>
+            ]])
+        end,
+    },
 }
 
 M.log.level = 'warn'

--- a/lua/yode-nvim/diffLib.lua
+++ b/lua/yode-nvim/diffLib.lua
@@ -132,10 +132,8 @@ M.findConnectedBlocks = function(diffData)
     local lineGroups = h.map(function(group)
         local findHappyStart = function(tokens)
             local dropTokensBeforeCount = R.max(1, tokens[1].index - CONNECTED_TOKEN_BORDER)
-            local tokensBeforeProbablyMiddleInLine = R.pipe(
-                R.drop(dropTokensBeforeCount - 1),
-                withoutInTokens
-            )(diffData.diffTokens)
+            local tokensBeforeProbablyMiddleInLine =
+                R.pipe(R.drop(dropTokensBeforeCount - 1), withoutInTokens)(diffData.diffTokens)
             local tokenTillStartOfLine = R.pipe(
                 R.take(dropTokensBeforeCount - 1),
                 withoutInTokens,
@@ -144,10 +142,8 @@ M.findConnectedBlocks = function(diffData)
                 end)
             )(diffData.diffTokens)
             local validDiffTokens = R.concat(tokenTillStartOfLine, tokensBeforeProbablyMiddleInLine)
-            local diffTokens = R.takeWhile(
-                R.complement(R.propEq('index', tokens[1].index)),
-                validDiffTokens
-            )
+            local diffTokens =
+                R.takeWhile(R.complement(R.propEq('index', tokens[1].index)), validDiffTokens)
             local diffLines = R.pipe(
                 R.take(R.min(START_END_COMPARE_COUNT, #tokens + CONNECTED_TOKEN_BORDER)),
                 M.joinTokenText,
@@ -155,16 +151,12 @@ M.findConnectedBlocks = function(diffData)
             )(validDiffTokens)
             local lineCount = R.length(diffLines)
             local baseText =
-                R.pipe(
-                    M.joinTokenText,
-                    R.split('\n'),
-                    R.take(lineCount),
-                    R.join('\n')
-                )(diffData.newTokens)
-            local startMatches = h.map(function(counter)
-                local diffLinesMatch = R.pipe(R.drop(counter), R.take(lineCount - counter))(
-                    diffLines
+                R.pipe(M.joinTokenText, R.split('\n'), R.take(lineCount), R.join('\n'))(
+                    diffData.newTokens
                 )
+            local startMatches = h.map(function(counter)
+                local diffLinesMatch =
+                    R.pipe(R.drop(counter), R.take(lineCount - counter))(diffLines)
                 local text = R.join('\n', diffLinesMatch)
                 local distance = getEditDistance(baseText, text)
 
@@ -230,11 +222,8 @@ M.findConnectedBlocks = function(diffData)
                 end),
                 R.join('')
             )
-            local additionalTokensTrimmed = h.over(
-                h.lensIndex(1),
-                h.over(h.lensProp('token'), trimToken),
-                additionalTokens
-            )
+            local additionalTokensTrimmed =
+                h.over(h.lensIndex(1), h.over(h.lensProp('token'), trimToken), additionalTokens)
             local grouWithHappyStart = R.concat(additionalTokensTrimmed, tokens)
 
             return startLine, grouWithHappyStart

--- a/lua/yode-nvim/handlers.lua
+++ b/lua/yode-nvim/handlers.lua
@@ -1,0 +1,12 @@
+local R = require('yode-nvim.deps.lamda.dist.lamda')
+local logging = require('yode-nvim.logging')
+local M = { fns = {} }
+
+M.setup = function(handlers)
+    local log = logging.create('handlers')
+    log.debug('args', handlers)
+    M.fns = R.pick({ 'onSeditorBufCal' }, handlers)
+    log.debug('computed', M.fns)
+end
+
+return M

--- a/lua/yode-nvim/helper.lua
+++ b/lua/yode-nvim/helper.lua
@@ -18,7 +18,7 @@ end
 local mapWithObjectKey = function(fn, data)
     return R.reduce(function(acc, key)
         return R.assoc(key, fn(data[key], key, data), acc)
-    end, {}, R.keys(data))
+    end, {}, M.keysSorted(data))
 end
 
 M.mapWithIndex = R.curry2(function(fn, data)
@@ -28,6 +28,8 @@ M.mapWithIndex = R.curry2(function(fn, data)
 
     return mapWithObjectKey(fn, data)
 end)
+
+M.keysSorted = R.pipe(R.keys, R.sort(R.lt))
 
 M.maxPositiveNumber = math.pow(2, 1024)
 --M.maxNegative = M.maxPositiveNumber * -1

--- a/lua/yode-nvim/init.lua
+++ b/lua/yode-nvim/init.lua
@@ -1,5 +1,6 @@
 local defaultConfig = require('yode-nvim.defaultConfig')
 local logging = require('yode-nvim.logging')
+local handlers = require('yode-nvim.handlers')
 local R = require('yode-nvim.deps.lamda.dist.lamda')
 local storeBundle = require('yode-nvim.redux.index')
 local store = storeBundle.store
@@ -17,8 +18,17 @@ local M = {
 local lastTabId = 1
 
 M.setup = function(options)
+    if not R.isEmpty(M.config) then
+        local log = logging.create('setup')
+        log.debug('already configured', M.config)
+        return
+    end
+
     M.config = vim.tbl_deep_extend('force', defaultConfig, options or {})
     logging.setup(M.config.log)
+    handlers.setup(M.config.handlers)
+    local log = logging.create('setup')
+    log.debug('configured with options', options, 'to', M.config)
 end
 
 M.yodeNvim = function()
@@ -27,7 +37,7 @@ M.yodeNvim = function()
     --testSetup.setup2()
     --testSetup.setup3()
 
-    vim.cmd('YodeBufferDelete')
+    --vim.cmd('YodeBufferDelete')
     --vim.cmd('tabnew')
     --vim.cmd('normal G')
     --vim.cmd('normal gg10j16dd')
@@ -117,10 +127,8 @@ M.cloneCurrentIntoFloat = function()
     local bufId = vim.fn.bufnr('%')
     local winId = vim.fn.win_getid()
 
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { bufId = bufId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { bufId = bufId })
     if floatWin then
         log.warn('buffer is already visible as floating window!')
         return
@@ -144,10 +152,8 @@ M.bufferDelete = function()
     local log = logging.create('bufferDelete')
     local winId = vim.fn.win_getid()
     local bufId = vim.fn.bufnr('%')
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { winId = winId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { winId = winId })
 
     if floatWin then
         log.debug('deleting floating window', bufId, winId)
@@ -216,10 +222,8 @@ end
 M.onBufWinEnter = function()
     local log = logging.create('onBufWinEnter')
     local winId = vim.fn.win_getid()
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { winId = winId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { winId = winId })
     if floatWin == nil then
         return
     end
@@ -262,10 +266,8 @@ end
 
 M.layoutShiftWinDown = function()
     local winId = vim.fn.win_getid()
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { winId = winId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { winId = winId })
     if floatWin == nil then
         vim.cmd('wincmd r')
         return
@@ -279,10 +281,8 @@ end
 
 M.layoutShiftWinUp = function()
     local winId = vim.fn.win_getid()
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { winId = winId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { winId = winId })
     if floatWin == nil then
         vim.cmd('wincmd R')
         return
@@ -296,10 +296,8 @@ end
 
 M.layoutShiftWinBottom = function()
     local winId = vim.fn.win_getid()
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { winId = winId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { winId = winId })
     if floatWin == nil then
         vim.cmd('wincmd J')
         return
@@ -313,10 +311,8 @@ end
 
 M.layoutShiftWinTop = function()
     local winId = vim.fn.win_getid()
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { winId = winId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { winId = winId })
     if floatWin == nil then
         vim.cmd('wincmd K')
         return
@@ -356,10 +352,8 @@ M.floatToMainWindow = function()
         return
     end
 
-    local floatWin = layout.selectors.getWindowBySomeId(
-        vim.api.nvim_get_current_tabpage(),
-        { bufId = bufId }
-    )
+    local floatWin =
+        layout.selectors.getWindowBySomeId(vim.api.nvim_get_current_tabpage(), { bufId = bufId })
     if not floatWin then
         log.debug('buffer is not floating, nothing to do')
         return

--- a/lua/yode-nvim/redux/index.lua
+++ b/lua/yode-nvim/redux/index.lua
@@ -37,10 +37,8 @@ local wrapWithDispatch = h.map(function(action)
     end
 end)
 
-M.store = createStore(
-    reducers,
-    applyMiddleware(stateLogger, layoutStateToNeovim, generalStateToNeovim)
-)
+M.store =
+    createStore(reducers, applyMiddleware(stateLogger, layoutStateToNeovim, generalStateToNeovim))
 M.seditors = {
     actions = wrapWithDispatch(seditorsReducer.actions),
     selectors = globalizeSelectors(STATE_PATH_SEDITORS, seditorsReducer.selectors),

--- a/lua/yode-nvim/redux/seditorsReducer.lua
+++ b/lua/yode-nvim/redux/seditorsReducer.lua
@@ -9,10 +9,8 @@ local INIT_SEDITOR = 'INIT_SEDITOR'
 M.actions.initSeditor = R.pipe(R.pick({ 'seditorBufferId', 'data' }), R.assoc('type', INIT_SEDITOR))
 
 local CHANGE_START_LINE = 'CHANGE_START_LINE'
-M.actions.changeStartLine = R.pipe(
-    R.pick({ 'seditorBufferId', 'amount' }),
-    R.assoc('type', CHANGE_START_LINE)
-)
+M.actions.changeStartLine =
+    R.pipe(R.pick({ 'seditorBufferId', 'amount' }), R.assoc('type', CHANGE_START_LINE))
 
 local CHANGE_DATA = 'CHANGE_DATA'
 M.actions.changeData = R.pipe(R.pick({ 'seditorBufferId', 'data' }), R.assoc('type', CHANGE_DATA))
@@ -32,10 +30,8 @@ M.actions.softlyKillSeditor = R.pipe(
 )
 
 M.actionNames.RESURRECT_SEDITOR = 'RESURRECT_SEDITOR'
-M.actions.resurrectSeditor = R.pipe(
-    R.pick({ 'seditorBufferId' }),
-    R.assoc('type', M.actionNames.RESURRECT_SEDITOR)
-)
+M.actions.resurrectSeditor =
+    R.pipe(R.pick({ 'seditorBufferId' }), R.assoc('type', M.actionNames.RESURRECT_SEDITOR))
 
 M.selectors.getSeditorById = function(id, state)
     return R.prop(id, state)

--- a/lua/yode-nvim/seditor.lua
+++ b/lua/yode-nvim/seditor.lua
@@ -48,10 +48,8 @@ M.checkLineDataIndentCount = function(sed, lineData)
         data = { indentCount = indentCount },
     })
     local currentLines = vim.api.nvim_buf_get_lines(sed.seditorBufferId, 0, -1, true)
-    local changedLines = h.map(
-        R.concat(h.createWhiteSpace(sed.indentCount - indentCount)),
-        currentLines
-    )
+    local changedLines =
+        h.map(R.concat(h.createWhiteSpace(sed.indentCount - indentCount)), currentLines)
 
     vim.schedule(function()
         vim.api.nvim_buf_set_lines(sed.seditorBufferId, 0, -1, true, changedLines)

--- a/lua/yode-nvim/tests/unit/helper_spec.lua
+++ b/lua/yode-nvim/tests/unit/helper_spec.lua
@@ -8,13 +8,23 @@ describe('helper', function()
         assert.True(h.maxPositiveNumber > 999999999999999999999999)
     end)
 
+    it('keysSorted', function()
+        eq({ 'bar', 'foo' }, h.keysSorted({ foo = 101, bar = 102 }))
+        eq({ 'bar', 'foo' }, h.keysSorted({ bar = 101, foo = 102 }))
+
+        eq({}, h.keysSorted({}))
+    end)
+
     it('map', function()
         eq({ 11, 12, 13 }, h.map(R.add(10), { 1, 2, 3 }))
         eq({ foo = 101, bar = 102 }, h.map(R.add(100), { foo = 1, bar = 2 }))
 
+        -- WARNING seems R.map doesn't gurantees in which order keys get mapped
+        local sort = R.sort(R.lt)
+
         -- for comparision what `R.map` does, which is not the behaviour of
         -- Ramda.map
-        eq({ 101, 102 }, R.map(R.add(100), { foo = 1, bar = 2 }))
+        eq(sort({ 101, 102 }), sort(R.map(R.add(100), { foo = 1, bar = 2 })))
     end)
 
     it('mapWithIndex', function()
@@ -30,9 +40,9 @@ describe('helper', function()
         )
 
         eq(
-            { foo = '10:foo:1020', bar = '20:bar:1020' },
-            h.mapWithIndex(function(data, i, all)
-                return data .. ':' .. i .. ':' .. R.join('', all)
+            { foo = '10:foo', bar = '20:bar' },
+            h.mapWithIndex(function(data, i)
+                return data .. ':' .. i
             end, {
                 foo = 10,
                 bar = 20,
@@ -41,9 +51,9 @@ describe('helper', function()
 
         -- this only works when props have values
         eq(
-            { bar = '20:bar:20' },
-            h.mapWithIndex(function(data, i, all)
-                return data .. ':' .. i .. ':' .. R.join('', all)
+            { bar = '20:bar' },
+            h.mapWithIndex(function(data, i)
+                return data .. ':' .. i
             end, {
                 foo = nil,
                 bar = 20,

--- a/lua/yode-nvim/tests/unit/init_setup_spec.lua
+++ b/lua/yode-nvim/tests/unit/init_setup_spec.lua
@@ -1,4 +1,5 @@
 local defaultConfig = require('yode-nvim.defaultConfig')
+local R = require('yode-nvim.deps.lamda.dist.lamda')
 local yodeNvim = require('yode-nvim.init')
 
 local eq = assert.are.same
@@ -15,6 +16,7 @@ describe('yode-nvim (init.lua)', function()
 
     it('setup with overrides', function()
         yodeNvim.setup({ log = { level = 'debug' } })
-        eq({ log = { level = 'debug' } }, yodeNvim.config)
+        eq({ log = { level = 'debug' } }, R.omit({ 'handlers' }, yodeNvim.config))
+        eq({ 'onSeditorBufCal' }, R.keys(yodeNvim.config.handlers))
     end)
 end)


### PR DESCRIPTION
This makes buffer mappings configurable. Set own mappings by:

```vim
"------------------------------
"yode-nvim
"------------------------------
lua << EOF
require('yode-nvim').setup({
    handlers = {
        onSeditorBufCal = function()
            vim.cmd([[
                imap <buffer> <leader>bly <esc>:YodeGoToAlternateBuffer t<cr>
            ]])
        end,
    },
})
EOF

```

Disable the mappings by:
```vim
"------------------------------
"yode-nvim
"------------------------------
lua << EOF
require('yode-nvim').setup({
    handlers = {
        onSeditorBufCal = function()
        end,
    },
})
EOF
```